### PR TITLE
Copyright year made dynamic in all the pages

### DIFF
--- a/ServiceSection/index.html
+++ b/ServiceSection/index.html
@@ -66,7 +66,7 @@
           <li><a href="/aboutUs">About</a></li>
           <li><a href="#">Contact</a></li>
           <li><a href="#">Blog</a></li>
-          <li><button id="bt1">Book Appointment</button></li>
+          <li><button id="bt1"><a href="../slotBooking/form.html">Book Appointment</a></button></li>
         </ul>
         <div id="bt2">
           <button><i class="fa-solid fa-bars"></i></button>
@@ -116,7 +116,7 @@
         <li><a href="/aboutUs">About</a></li>
         <li><a href="#">Contact</a></li>
         <li><a href="#">Blog</a></li>
-        <li><button>Book Appointment</button></li>
+        <li><button id="mobBT"><a href="../slotBooking/form.html">Book Appointment</a></button></li>
       </ul>
     </nav>
     <!-- Navbar Section Finished -->
@@ -329,9 +329,7 @@
           <hr style="margin: 0 auto; width: 90%; margin-top: 10px" />
   
           <div class="root">
-            <div class="footer-copyright">
-              Copyright © 2023 <a href="#">Aiskcon</a>, All Right Reserved
-            </div>
+            <div class="footer-copyright"></div>
           </div>
         </div>
       </footer>

--- a/aboutUs/index.html
+++ b/aboutUs/index.html
@@ -479,9 +479,7 @@
         <hr style="margin: 0 auto; width: 90%; margin-top: 10px" />
 
         <div class="root">
-          <div class="footer-copyright">
-            Copyright © 2023 <a href="#">Aiskcon</a>, All Right Reserved
-          </div>
+          <div class="footer-copyright"></div>
         </div>
       </div>
     </footer>

--- a/aboutUs/main.js
+++ b/aboutUs/main.js
@@ -10,3 +10,10 @@ const swiper = new Swiper('.swiper', {
     disableOnInteraction:false,
   },
 });
+
+
+if(document.querySelector('.footer-copyright')){
+  let year = new Date();
+  year = year.getFullYear();
+  document.querySelector('.footer-copyright').innerHTML = 'Copyright &#169; ' + year + ' <a href="#">Aiskcon</a>, All Right Reserved';
+}

--- a/aboutUs/main.js
+++ b/aboutUs/main.js
@@ -15,5 +15,5 @@ const swiper = new Swiper('.swiper', {
 if(document.querySelector('.footer-copyright')){
   let year = new Date();
   year = year.getFullYear();
-  document.querySelector('.footer-copyright').innerHTML = 'Copyright &#169; ' + year + ' <a href="#">Aiskcon</a>, All Right Reserved';
+  document.querySelector('.footer-copyright').innerHTML = 'Copyright &#169; ' + year + ' <a href="/">Aiskcon</a>, All Right Reserved';
 }

--- a/index.html
+++ b/index.html
@@ -713,9 +713,7 @@
         <hr style="margin: 0 auto; width: 90%; margin-top: 10px" />
 
         <div>
-          <div class="footer-copyright">
-            Copyright © 2023 <a href="#">Aiskcon</a>, All Right Reserved
-          </div>
+          <div class="footer-copyright"></div>
         </div>
       </div>
     </footer>

--- a/js/main.js
+++ b/js/main.js
@@ -107,3 +107,10 @@ faqQuestions.forEach((question) => {
     }
   });
 });
+
+
+if(document.querySelector('.footer-copyright')){
+  let year = new Date();
+  year = year.getFullYear();
+  document.querySelector('.footer-copyright').innerHTML = 'Copyright &#169; ' + year + ' <a href="#">Aiskcon</a>, All Right Reserved';
+}

--- a/js/main.js
+++ b/js/main.js
@@ -112,5 +112,5 @@ faqQuestions.forEach((question) => {
 if(document.querySelector('.footer-copyright')){
   let year = new Date();
   year = year.getFullYear();
-  document.querySelector('.footer-copyright').innerHTML = 'Copyright &#169; ' + year + ' <a href="#">Aiskcon</a>, All Right Reserved';
+  document.querySelector('.footer-copyright').innerHTML = 'Copyright &#169; ' + year + ' <a href="/">Aiskcon</a>, All Right Reserved';
 }

--- a/slotBooking/form.html
+++ b/slotBooking/form.html
@@ -255,9 +255,7 @@
             <hr style="margin: 0 auto; width: 90%; margin-top: 10px;">
 
             <div class="root">
-                <div class="footer-copyright">
-                    Copyright © 2023 <a href="#">Aiskcon</a>, All Right Reserved
-                </div>
+                <div class="footer-copyright"></div>
             </div>
         </div>
     </footer>

--- a/slotBooking/script.js
+++ b/slotBooking/script.js
@@ -152,3 +152,9 @@ inBoxes.forEach((element)=>{
     });
 });
 // Slot Booking end
+
+if(document.querySelector('.footer-copyright')){
+    let year = new Date();
+    year = year.getFullYear();
+    document.querySelector('.footer-copyright').innerHTML = 'Copyright &#169; ' + year + ' <a href="#">Aiskcon</a>, All Right Reserved';
+}

--- a/slotBooking/script.js
+++ b/slotBooking/script.js
@@ -156,5 +156,5 @@ inBoxes.forEach((element)=>{
 if(document.querySelector('.footer-copyright')){
     let year = new Date();
     year = year.getFullYear();
-    document.querySelector('.footer-copyright').innerHTML = 'Copyright &#169; ' + year + ' <a href="#">Aiskcon</a>, All Right Reserved';
+    document.querySelector('.footer-copyright').innerHTML = 'Copyright &#169; ' + year + ' <a href="/">Aiskcon</a>, All Right Reserved';
 }


### PR DESCRIPTION
closes #66 

Copyright year made dynamic in all the pages using the following JavaScript logic: -
![Screenshot (172)](https://user-images.githubusercontent.com/118634923/231273498-7cf5980d-c8c7-4227-ab64-b69524d2e712.png)
