### PR TITLE
Background image of Why Choose Us section is fixed while scrolling

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -607,6 +607,7 @@ ul {
 .whyChooseUs-section {
   background: url('/img/bg/whychooseus.jpg');
   background-size: cover;
+  background-attachment: fixed;
   padding: 0;
 }
 .whychooseus-overlay {


### PR DESCRIPTION
closes #78 

![Screenshot (178)](https://user-images.githubusercontent.com/118634923/231550407-81c6d53b-9608-4a7e-981e-9b2485becb71.png)
