### PR TITLE
Navigation Bug is Fixed

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -6,6 +6,10 @@
   font-family: 'Roboto', sans-serif;
 }
 
+html {
+  scroll-padding-top: 79px;
+}
+
 :root {
   --primary: #046c5c;
   --secondary: #0f2f51;

--- a/css/style.css
+++ b/css/style.css
@@ -7,7 +7,7 @@
 }
 
 html {
-  scroll-padding-top: 79px;
+   scroll-padding-top: 79px;
 }
 
 :root {


### PR DESCRIPTION
## Summary
When we have a fixed navigation with anchor links that go to different locations within the page, that navigation can cover content when it scrolls to that location on the page.
I have fixed this issue by setting the scroll padding-top same as the Navigation height

## Bug
https://github.com/AbhiPatel10/AISKCON-CONSTRUCTION/assets/87256781/176cba0f-b7f2-4058-8d53-cec3fcd0b436

## Fixes #189 
https://github.com/AbhiPatel10/AISKCON-CONSTRUCTION/assets/87256781/e5203813-11e1-4ad8-a56f-9d4716ba1dbc




## Type of change
_Please select the relevant option._
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe)

## Checklist
_Please tick the relevant options._
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.

## Additional context
I have just added a one-line code in the CSS file.
